### PR TITLE
Feat: Allow xendomains to restart DomU when reboot/shutdown

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,3 +84,9 @@
   when:
     - xen__configure
     - not xen__use_libvirt_network
+
+- name: Create xendomains systemd service file
+  template:
+    src: xendomains.service
+    dest: /etc/systemd/system/xendomains.service
+  when: xen__install

--- a/templates/xendomains.service
+++ b/templates/xendomains.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Xen domains restart service
+After=xen.service
+Wants=xen.service
+
+#Requires=proc-fs-nfsd.mount
+#After=proc-fs-nfsd.mount
+#After=network.target local-fs.target
+#BindsTo=nfs-server.service
+
+[Service]
+ExecStart=/etc/init.d/xendomains start
+# Restart=always
+# RestartSec=10s
+# User=
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Using xendomains service, forcing it to be enabled, we can restart DomU