### PR TITLE
Fix: Use onshot option for xendomains

### DIFF
--- a/templates/xendomains.service
+++ b/templates/xendomains.service
@@ -4,8 +4,9 @@ After=xen.service
 Wants=xen.service
 
 [Service]
-Type=forking
+Type=oneshot
 ExecStart=/etc/init.d/xendomains start
+ExecStop=/etc/init.d/xendomains stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* Use execstop for stopping (and potentially saving) VMs
* Type=oneshot wait until ExecStart to set the service as Ready (dead)